### PR TITLE
Fix file write statement

### DIFF
--- a/R/vcf2nexus.R
+++ b/R/vcf2nexus.R
@@ -32,6 +32,6 @@ vcf2nexus <- function(vcf, file = "file.nex") {
   nex.file[fmt] <- "  FORMAT DATATYPE=INTEGER MISSING=? GAP=- SYMBOLS=\"012\" LABELS=LEFT TRANSPOSE=NO INTERLEAVE=NO;"
 
   #return(snapp.file)
-  write(snapp.file, file)
+  write(nex.file, file)
 
 }


### PR DESCRIPTION
Are you working on this as a package? I came across this and wanted to try and use your function. Looks like my my nexus file got written by ape, though the final write statement failed with `Error in write(snapp.file, file) : object 'snapp.file' not found`. My guess is that you copy-pasted this from vcf2SNAPP and just missed the object name change on line 35. Is there a big difference between the nexus file outputted from this vs output for vcf2SNAPP?